### PR TITLE
feat: search only acronyms column, search from start of words

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,9 @@
     <meta name="description" property="og:description" content="This site attempts to document all the acronyms used in order to improve everyone's understanding in the workplace.">
     <meta name="image" property='og:image' content='https://i.imgflip.com/5dm82z.jpg'/>
     <!--datatables-->
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jq-3.6.0/dt-1.11.4/r-2.2.9/datatables.min.css"/>
-    <script type="text/javascript" src="https://cdn.datatables.net/v/dt/jq-3.6.0/dt-1.11.4/r-2.2.9/datatables.min.js"></script>
-
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.css" />
+    <script src="https://cdn.datatables.net/2.0.8/js/dataTables.js"></script>
   </head>
 
   <body class="govuk-template__body  js-enabled">
@@ -83,11 +83,12 @@
                 </ul>
         </div>
 
+        <div class="govuk-form-group">
+          <h1 class="govuk-label-wrapper">
+          </h1>
+          <input class="govuk-input" id="acronym-search" name="acronymSearch" placeholder="Search" type="text">
+        </div>
 
-        <div id="searchBox">
-
-
-      </div>
       </div>
       </div>
 

--- a/index.html.j2
+++ b/index.html.j2
@@ -46,7 +46,7 @@
             </span>
           </p>
         </div>
-
+<a href="https://toolsforcivilservants.co.uk" class="govuk-back-link">Tools for Civil Servants</a>
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
 
 

--- a/index.html.j2
+++ b/index.html.j2
@@ -23,9 +23,9 @@
     <meta name="description" property="og:description" content="This site attempts to document all the acronyms used in order to improve everyone's understanding in the workplace.">
     <meta name="image" property='og:image' content='https://i.imgflip.com/5dm82z.jpg'/>
     <!--datatables-->
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jq-3.6.0/dt-1.11.4/r-2.2.9/datatables.min.css"/>
-    <script type="text/javascript" src="https://cdn.datatables.net/v/dt/jq-3.6.0/dt-1.11.4/r-2.2.9/datatables.min.js"></script>
-
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.css" />
+    <script src="https://cdn.datatables.net/2.0.8/js/dataTables.js"></script>
   </head>
 
   <body class="govuk-template__body  js-enabled">
@@ -83,11 +83,12 @@
                 </ul>
         </div>
 
+        <div class="govuk-form-group">
+          <h1 class="govuk-label-wrapper">
+          </h1>
+          <input class="govuk-input" id="acronym-search" name="acronymSearch" placeholder="Search" type="text">
+        </div>
 
-        <div id="searchBox">
-
-
-      </div>
       </div>
       </div>
 

--- a/siteAssets/datatables.js
+++ b/siteAssets/datatables.js
@@ -1,28 +1,29 @@
 
 
-$(document).ready( function () {
-    $('#table_id').DataTable({
-      responsive: {
-        details: false
-      },
+$(document).ready(function () {
+  let table = $('#table_id').DataTable({
+    layout: {topEnd: null},
+    responsive: {
+      details: false
+    },
+    columnDefs: [
+      { responsivePriority: 1, targets: 0 },
+      { responsivePriority: 2, targets: 1 },
+      { responsivePriority: 3, targets: 2 },
+      { responsivePriority: 4, targets: 3 }
+    ],
+    initComplete: function () {
+      $('#acronym-search').on('keyup', function () {
+        // Search only the acronym column (index 0)
+        table.column(0).search($(this).val(), { boundary: true }).draw();
+      });
+    }
+  });
 
-      "language": {
-            "search": "_INPUT_",            // Removes the 'Search' field label
-            "searchPlaceholder": "Search"   // Placeholder for the search box
-        },
-      columnDefs: [
-          { responsivePriority: 1, targets: 0 },
-          { responsivePriority: 2, targets: 1 },
-          { responsivePriority: 3, targets: 2 },
-          { responsivePriority: 4, targets: 3 }
-      ]
-    });
-} );
-$(document).ready(function() {
-  $('div.dataTables_filter input').addClass('govuk-input govuk-input--width-');
-  $('div.dataTables_filter').addClass('govuk-form-group');
-  $("div.dataTables_filter").removeClass("dataTables_filter");
-  $("#table_id_filter").detach().appendTo('#searchBox');
+
+});
+$(document).ready(function () {
+
   $("div.dataTables_length select").addClass("govuk-select");
-  $('div.govuk-form-group input').attr("onblur", "gtag('event', 'search', {search_term: this.value}");
-} );
+  $('div.govuk-form-group input').attr("onblur", "gtag('event', 'search', {search_term: this.value})");
+});


### PR DESCRIPTION
Hey Sam!

I think this improves the search, by:

- Searching only the acronyms column
- Searching only from the start of words ([boundary: true](https://datatables.net/reference/type/DataTables.SearchOptions#boundary))

The latter seemed to require upgrading to datatables V2, which appears to bring some minor styling changes (e.g. buttons below the table look slightly different).

Try "HMRC" as an example of the difference.

I think a further improvement would be to exclude text in brackets () from search, as e.g. "CO" or "SC" still don't give great results.